### PR TITLE
Fix fraud detection join condition to respect travel flags

### DIFF
--- a/03-fraud-detection/src/main/java/com/example/HighTravelDistanceTopology.java
+++ b/03-fraud-detection/src/main/java/com/example/HighTravelDistanceTopology.java
@@ -59,7 +59,7 @@ class HighTravelDistanceTopology {
     KTable<String, TravelFlags> travelFlags =
         builder.table("travel_flags", travelFlagsConsumerOptions);
 
-    Joined joinParams =
+    Joined<String, Purchase, TravelFlags> joinParams =
         Joined.with(
             Serdes.String(), /* key */
             AvroSerdes.Purchase(REDPANDA_SCHEMA_REGISTRY_URL), /* left value */
@@ -69,7 +69,7 @@ class HighTravelDistanceTopology {
         purchases
             .filter(
                 (key, value) -> value.getDistanceFromBillingZip() >= HIGH_TRAVEL_DISTANCE_THRESHOLD)
-            .leftJoin(travelFlags, (left, right) -> new JoinValue(left, right != null), joinParams);
+            .leftJoin(travelFlags, (left, right) -> new JoinValue(left, right != null && right.getEnabled()), joinParams);
 
     KStream<String, Alert> alerts =
         joined.flatMapValues(


### PR DESCRIPTION
The "high travel distance" fraud detection sample uses a table to decide if the given card is in "travel mode" so that no alerts are triggered even if the purchase is done from more than 2000 miles away.

The join of purchases with travel flags relied on the pure existence of an entry instead of respecting the value of the travel flag. Deactivating the travel mode by inserting a new entry with `enabled=false` (incrementing id mode) would still not trigger an alert because the `JoinValue.travelFlagOn` was still set to true.

This fixes the join condition to respect the value of the `travel_flag.enabled` and still assumes the default of `disabled` if there is no entry for that card.