### PR TITLE
Rollback image to get WASM working again

### DIFF
--- a/01-stream-processing-basics/docker-compose.yml
+++ b/01-stream-processing-basics/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:v23.1.7
+    image: docker.redpanda.com/vectorized/redpanda:v22.2.1
     container_name: redpanda-1
     command:
       - redpanda


### PR DESCRIPTION
Rollback the image just for the WASM lesson to get it working. We'll upgrade again once the eng work that Christina mentioned is finished.

Related: https://github.com/redpanda-data-university/rp-102-stream-processing/issues/4